### PR TITLE
Replace /usr/bin/python with /usr/bin/env python

### DIFF
--- a/ossipee-create
+++ b/ossipee-create
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import logging
 import ossipee

--- a/ossipee-display
+++ b/ossipee-display
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import logging
 

--- a/ossipee-host
+++ b/ossipee-host
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import argparse
 import logging
 import ossipee

--- a/ossipee-list
+++ b/ossipee-list
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import logging
 

--- a/ossipee-redo
+++ b/ossipee-redo
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import logging
 

--- a/ossipee-teardown
+++ b/ossipee-teardown
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import logging
 


### PR DESCRIPTION
If you are running ossipee in a virtualenv (which is a good idea) then
running scripts that link directly to /usr/bin/python will bust you out
of that virtualenv and it will be unable to find the required packages.

By running with /usr/bin/env python instead it will source the python
from the virtualenv you are using.
