### PR TITLE
Add setuptools tooling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pbr
 python-neutronclient
 python-novaclient
 python-keystoneclient

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,32 @@
+[metadata]
+name = ossipee
+summary = A utility for creating test virtual machine networks
+description-file =
+    README.rst
+author = Adam Young
+author-email = ayoung@redhat.com
+home-page = http://adam.younglogic.com/
+classifier =
+    Environment :: OpenStack
+    Programming Language :: Python
+    Programming Language :: Python :: 2
+    Programming Language :: Python :: 2.7
+
+[files]
+packages =
+    ossipee
+    osipa
+
+scripts =
+    ossipee-create
+    ossipee-display
+    ossipee-host
+    ossipee-list
+    ossipee-redo
+    ossipee-teardown
+
+[pbr]
+warnerrors = True
+
+[wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,13 @@
+import setuptools
+
+# In python < 2.7.4, a lazy loading of package `pbr` will break
+# setuptools if some other modules registered functions in `atexit`.
+# solution from: http://bugs.python.org/issue15881#msg170215
+try:
+    import multiprocessing  # noqa
+except ImportError:
+    pass
+
+setuptools.setup(
+    setup_requires=['pbr>=1.3'],
+    pbr=True)


### PR DESCRIPTION
Add a setup.py so that I can pip install -e . into a virtualenv
rather than have to keep jumping back to the folder to run ossipee
commands.

I use PBR because it's good for simple things like this and it makes it
easier to reuse logic from other openstack projects.
