### PR TITLE
Clear both IP and hostname from known_hosts

### DIFF
--- a/ossipee.py
+++ b/ossipee.py
@@ -339,7 +339,6 @@ class FloatIP(WorkItem):
                 break
 
     def reset_ssh(self, ip_address):
-        subprocess.call(['ssh-keygen', '-R', ip_address])
         attempts = 5
         while(attempts):
             try:
@@ -367,6 +366,8 @@ class FloatIP(WorkItem):
         fqdn = self.make_fqdn(self.name)
         server = self.get_server_by_name(fqdn)
         ip_address = self.assign_next_ip(server)
+        subprocess.call(['ssh-keygen', '-R', fqdn])
+        subprocess.call(['ssh-keygen', '-R', ip_address])
         self.reset_ssh(ip_address)
 
     def display(self):
@@ -732,7 +733,7 @@ class Application(object):
                     sys.exit(-1)
             except AttributeError:
                 pass
-            
+
             self._session = ksc_session.Session.load_from_cli_options(
                 self.args,
                 auth=auth_plugin)


### PR DESCRIPTION
Currently we clear the ssh key associated with an IP address from the
known_hosts file as this changes every time you redo an ossipee run. In
my case i've got a hosts entry because i need to use the hostname when
connecting via browser for SSL and testing websso flows.

This means i also tend to use the hostname when SSH-ing but this doesn't
get reset.

Reset the hostname ssh key as well, but don't try to ssh connect to it
as it may not have an entry in hosts.
